### PR TITLE
Fix coupon harvest workflow

### DIFF
--- a/.github/workflows/coupon-harvest.yml
+++ b/.github/workflows/coupon-harvest.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Playwright + deps
         run: |
-          npm ci
+          npm install
           npx playwright install chromium
 
       - name: Harvester futtatás


### PR DESCRIPTION
Use npm install instead of npm ci (no lockfile in repo) for coupon-harvest workflow.