### PR TITLE
docs(governance): add impact_hub local governance entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ wp-content/mu-plugins/*
 !/docs/system-recovery-map.md
 !/docs/impactshop-badge-system.md
 !/docs/pr-policy.md
+!/docs/ai-assistant-canonical-policy.md
+!/docs/impact-hub-governance-system-plan-2026-06-16.md
 /bin/
 /impactshop-baseline-2025-10-15.md
 /impactshop-link-diagnostics.php

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Workspace global policy: `/Users/bujdosoarnold/AGENTS.md`
 - Shared assistant policy: `/Users/bujdosoarnold/Developer/GitHub/ai-agent/docs/ai-assistant-canonical-policy.md`
 - Local assistant policy: `docs/ai-assistant-canonical-policy.md`
+- Local governance hub / system plan: `docs/impact-hub-governance-system-plan-2026-06-16.md`
 - PR / merge / deploy policy: `docs/pr-policy.md`
 
 If any local assistant configuration conflicts with these files, treat the above list as canonical in that order.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # impact_hub
+
+## Governance Start Here
+
+- Helyi kanonikus governance-hub: `docs/impact-hub-governance-system-plan-2026-06-16.md`
+- Helyi assistant policy anchor: `docs/ai-assistant-canonical-policy.md`
+- Repo munkaszabalyok: `AGENTS.md`
+- PR / merge / deploy policy: `docs/pr-policy.md`
+- Exit checklist: `PR-EXIT-CHECKLIST.md`

--- a/docs/ai-assistant-canonical-policy.md
+++ b/docs/ai-assistant-canonical-policy.md
@@ -1,0 +1,28 @@
+# Impact Hub Local Assistant Policy
+
+Datum: 2026-06-16
+Statusz: local policy anchor
+Scope: rovid helyi policy-anchor az `impact_hub` repo sajat governance lancahoz.
+
+## Role
+
+Ez a dokumentum nem a workspace-global vagy shared policy helyett all, hanem helyi referenciapontkent rogzit ket dolgot:
+
+1. az `impact_hub` repo a sajat `AGENTS.md` + `docs/pr-policy.md` + `PR-EXIT-CHECKLIST.md` + `docs/system-recovery-map.md` anchorjain keresztul ertelmezendo;
+2. ha barmely helyi automation, asszisztens vagy handover kontextus nem egyertelmu, a helyi governance entrypoint:
+   - `docs/impact-hub-governance-system-plan-2026-06-16.md`
+
+## Local Rules
+
+1. Nem trivialis munka dedikalt feature/worktree alapon tortenjen.
+2. Docs, runtime, deploy es recovery lane-ek ne keveredjenek feleslegesen.
+3. Guard vagy recovery erintesnel rollback/restore tisztasag kotelezo.
+4. Valos allapotvaltozasnal `system-status-snapshot.md` es `notes.md` folytonossag kotelezo.
+
+## Canonical Local References
+
+- `AGENTS.md`
+- `docs/pr-policy.md`
+- `PR-EXIT-CHECKLIST.md`
+- `docs/system-recovery-map.md`
+- `docs/impact-hub-governance-system-plan-2026-06-16.md`

--- a/docs/impact-hub-governance-system-plan-2026-06-16.md
+++ b/docs/impact-hub-governance-system-plan-2026-06-16.md
@@ -1,0 +1,84 @@
+# Impact Hub Governance System Plan
+
+Datum: 2026-06-16
+Statusz: canonical local governance hub
+Scope: rovid, repo-helyi belepesi pont az `impact_hub` governance, review, continuity es deploy/guard szabalyaihoz.
+
+## Cel
+
+Ez a dokumentum nem uj policy-t vezet be. A celja az, hogy egyetlen helyi rendszertervi/guidance pontban osszefogja azokat a mar ervenyes anchorokat, amelyek alapjan az `impact_hub` repo-ban a munka, review, continuity, guard es recovery rendje kovetheto.
+
+## Canonical Anchors
+
+1. `AGENTS.md`
+   - repo-szintu policy-sorrend, worktree discipline, nyelv es session workflow minimum
+2. `docs/pr-policy.md`
+   - a kotelezo one-path workflow commit/push/PR/deploy kapukkal
+3. `PR-EXIT-CHECKLIST.md`
+   - a merge elotti kotelezo kilepesi feltetelek rovid ellenorzolistaja
+4. `docs/ai-assistant-canonical-policy.md`
+   - helyi AI-asszisztens policy-anchor ehhez a repohoz
+5. `docs/system-recovery-map.md`
+   - backup, guard, recovery es rendszerterkep source of truth
+6. `system-status-snapshot.md`
+   - a repo aktualis allapot- es valtozasnaploja
+7. `notes.md`
+   - session-szintu dontes-, kockazat- es handover naplo
+
+## Recommended Reading Order
+
+1. `AGENTS.md`
+2. `docs/pr-policy.md`
+3. `PR-EXIT-CHECKLIST.md`
+4. `docs/system-recovery-map.md`
+5. `system-status-snapshot.md`
+6. `notes.md`
+
+## Operating Model
+
+1. Smallest reviewable slice first
+   - egyszerre egy szuk, jol auditalhato szelet menjen
+2. One-path workflow
+   - nem trivialis munka dedikalt feature/worktree alapon tortenik
+   - merge es deploy a helyi policy szerint guardolt
+3. Fail-closed infra and deploy thinking
+   - guard, recovery vagy deploy-lane valtozasnal mindig rollback/recovery tisztasag kell
+4. Continuity by default
+   - valos allapotvaltozas eseten a docs + `system-status-snapshot.md` + `notes.md` egyutt frissul
+
+## Decision Rules
+
+### Docs-only slice
+
+Docs-only szelet a helyes valasztas, ha:
+
+- a kovetkezo lepes governance, review, continuity vagy source-of-truth hianyossagot zar
+- runtime vagy deploy-lane touch nem kotelezo
+- a kovetkezo implementacios kor ettol egyertelmubb es biztonsagosabb lesz
+
+### Runtime / guard / deploy slice
+
+Ilyen szeletnel kotelezo:
+
+- a relevans guard vagy recovery referencia beazonositasa
+- rollback vagy restore ut rogzites
+- focused validation vagy smoke evidence
+- continuity update a valos allapot szerint
+
+## Scope Boundary
+
+Ez a hub helyi entrypoint, nem valtja ki:
+
+- a workspace-global policy-t
+- a shared `ai-agent` policyt
+- a reszletes guard/recovery runbookokat
+- a feature-specifikus termekdokumentumokat
+
+## Natural Next Use
+
+Ez a dokumentum arra valo, hogy a kovetkezo helyi munkaknal legyen egy rovid, biztos belepesi pont:
+
+- uj docs vagy governance szelet inditasakor
+- PR/review elott
+- guard vagy deploy-lane erintese elott
+- handover es continuity ellenorzeshez

--- a/docs/system-recovery-map.md
+++ b/docs/system-recovery-map.md
@@ -6,6 +6,7 @@
 - **Repo path:** `/Users/bujdosoarnold/Developer/GitHub/impact_hub`
 - **Git:** `main @ 9fa19e3` (working tree state varies; check `git status`)
 - **Baselines:** `impactshop-baseline-2025-11-02.md` (primary), `system-status-snapshot.md` (rolling log)
+- **Local governance entrypoint:** `docs/impact-hub-governance-system-plan-2026-06-16.md`
 - **Guards:** `~/bin/impactall` (13/13 PASS) with alerts flowing to Discord webhook defined in `.codex/.env.guard`
 - **WP REST:** `https://www.sharity.hu/impactshop-staging/wp-json/` → HTTP 200 (redirects to prod host intentionally); Production `https://app.sharity.hu/wp-json/` → HTTP 200
 - **Secrets:** `.codex/.env` exports `GITHUB_TOKEN` (classic PAT – renewal required before manual expiry) and alert recipients

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,4 @@
+## 2026-06-16 10:45 CEST - local governance hub/system-plan
+- Docs-only governance szeletkent letrejott a helyi belepesi pont: `docs/impact-hub-governance-system-plan-2026-06-16.md`.
+- A szelet egy valos koherenciarest is lezart: a korabban hivatkozott, de hianyzo `docs/ai-assistant-canonical-policy.md` most mar minimalis helyi policy-anchor formaban repo-tracked.
+- Bekotes megtortent az `AGENTS.md`, `README.md`, `docs/system-recovery-map.md` es `system-status-snapshot.md` iranyabol.

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -1,4 +1,9 @@
 
+## 2026-06-16T10:45:00+0200 - local governance hub and policy anchor added
+- Uj rovid, repo-helyi governance entrypoint keszult: `docs/impact-hub-governance-system-plan-2026-06-16.md`.
+- A korabbi canonical hivatkozasi rest is lezarja ez a kor: a hianyzo `docs/ai-assistant-canonical-policy.md` most mar explicit helyi policy-anchor.
+- Bekotes megtortent az `AGENTS.md`, `README.md` es `docs/system-recovery-map.md` felol, igy a helyi governance lanc mar feloldhato egyetlen repo-beli belepesi pontrol.
+
 ---
 2026-03-23T12:25:00Z | fix(harvester): bound coupon harvester runtime in CI — GitHub Actions harvest job timeout set to 45 minutes, `timeout 40m` wraps the runtime command, and CLI entrypoint now exits explicitly on success to reduce hung scheduled runs
 


### PR DESCRIPTION
## Summary
- add a short repo-local governance hub/system plan for `impact_hub`
- restore the missing local assistant policy anchor so the local canonical chain is resolvable
- wire the new entrypoint into AGENTS, README, system recovery docs, snapshot, and notes continuity

## Scope
- docs-only governance and continuity slice
- no runtime, deploy, or guard behavior changes

## Risk
- low
- additive documentation only

## Validation
- `git diff --check`
- `bash scripts/safe-repo-audit.sh --strict --mode push`
- targeted anchor/link presence checks

## Continuity
- added `notes.md`
- updated `system-status-snapshot.md`
- updated `docs/system-recovery-map.md`

## Rollback
- revert commit `a6f2f79` on branch `docs/impact-hub-governance-hub-20260616`
- remove the local governance hub/policy anchor references if rollback is needed

## PR Exit Checklist (Required)
- [x] 1. Work was done on dedicated branch/worktree (not `main`)
- [x] 2. Relevant build/tests ran and are green
- [x] 3. `safe-repo-audit.sh --strict --mode push` is green
- [x] 4. `system-status-snapshot.md` updated for module change
- [x] 5. At least one `docs/*.md` updated for module change
- [x] 6. `notes.md` or `conversation-summaries/*` updated (notes-context repos)
- [x] 7. `docs/bastion-guard-status.md` updated when new module file was added
- [x] 8. Deploy guard + smoke checks are logged (if deploy happened)
- [x] 9. Backup/rollback path is recorded
- [x] 10. PR description includes scope, risk, validation, deploy/rollback notes
