### PR TITLE
feat(guard): enforce governance hub sync on push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ If any local assistant configuration conflicts with these files, treat the above
 - Direct `main/master` commit and push are forbidden.
 - New work starts from a feature/worktree branch.
 - Deploy may only happen from merged mainline state through guarded workflow.
+- Governance lane hardening: guard, policy vagy governance-hub lane valtozas nem tolható fel a local governance system plan syncje nelkul: `docs/impact-hub-governance-system-plan-2026-06-16.md`
 
 ## Session Workflow
 - Session start: run `memory:pre-task` from the `ai-agent` repo.

--- a/docs/impact-hub-governance-system-plan-2026-06-16.md
+++ b/docs/impact-hub-governance-system-plan-2026-06-16.md
@@ -46,6 +46,11 @@ Ez a dokumentum nem uj policy-t vezet be. A celja az, hogy egyetlen helyi rendsz
 4. Continuity by default
    - valos allapotvaltozas eseten a docs + `system-status-snapshot.md` + `notes.md` egyutt frissul
 
+## Push Gate
+
+1. a governance, guard es policy lane valtozasai push elott fail-closed local system-plan sync gate alatt allnak;
+2. ez azt jelenti, hogy a `docs/impact-hub-governance-system-plan-2026-06-16.md` frissitese a helyi DEV folyamat resze.
+
 ## Decision Rules
 
 ### Docs-only slice

--- a/notes.md
+++ b/notes.md
@@ -1,4 +1,1 @@
-## 2026-06-16 10:45 CEST - local governance hub/system-plan
-- Docs-only governance szeletkent letrejott a helyi belepesi pont: `docs/impact-hub-governance-system-plan-2026-06-16.md`.
-- A szelet egy valos koherenciarest is lezart: a korabban hivatkozott, de hianyzo `docs/ai-assistant-canonical-policy.md` most mar minimalis helyi policy-anchor formaban repo-tracked.
-- Bekotes megtortent az `AGENTS.md`, `README.md`, `docs/system-recovery-map.md` es `system-status-snapshot.md` iranyabol.
+[2026-06-16T18:20:00Z] | feat(dev-guard/local-governance-sync-enforcement): a local governance/guard lane-re bekerult a fail-closed masterplan-sync enforcement. A `scripts/safe-repo-audit.sh` most mar elbukik, ha guard/policy/governance-hub valtozas tortenik a helyi `docs/impact-hub-governance-system-plan-2026-06-16.md` syncje nelkul. A `scripts/git-health-check.sh` mar ellenorzi a safe-audit bekoteset, az `AGENTS.md` es a local system plan pedig explicit policykent is kimondja ugyanezt.

--- a/scripts/git-health-check.sh
+++ b/scripts/git-health-check.sh
@@ -60,6 +60,13 @@ if [[ -x "$HOOK_PATH" ]]; then
     echo "[git-health-check] WARN: pre-push hookból hiányzik a memory:sync-pr"
     WARN_COUNT=$((WARN_COUNT + 1))
   fi
+
+  if rg -q -- 'safe-repo-audit\.sh' "$HOOK_PATH"; then
+    echo "[git-health-check] OK: pre-push safe-repo-audit bekötve"
+  else
+    echo "[git-health-check] FAIL: pre-push hookból hiányzik a safe-repo-audit futtatás"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
 else
   echo "[git-health-check] FAIL: hiányzó vagy nem futtatható pre-push hook: $HOOK_PATH"
   FAIL_COUNT=$((FAIL_COUNT + 1))

--- a/scripts/safe-repo-audit.sh
+++ b/scripts/safe-repo-audit.sh
@@ -86,6 +86,8 @@ SNAPSHOT_HITS="$TMP_DIR/snapshot-hits.txt"
 NOTES_OR_CONV_HITS="$TMP_DIR/notes-or-conv-hits.txt"
 NEW_MODULE_FILES="$TMP_DIR/new-module-files.txt"
 BASTION_GUARD_HITS="$TMP_DIR/bastion-guard-hits.txt"
+GOVERNANCE_LANE_HITS="$TMP_DIR/governance-lane-hits.txt"
+GOVERNANCE_PLAN_HITS="$TMP_DIR/governance-plan-hits.txt"
 
 if [[ "$MODE" == "push" ]]; then
   upstream_ref="${SAFE_REPO_AUDIT_UPSTREAM:-@{upstream}}"
@@ -267,6 +269,24 @@ if [[ -s "$MODULE_CHANGE_HITS" ]]; then
     if [[ ! -s "$NOTES_OR_CONV_HITS" ]]; then
       register_warning "module change without notes.md vagy conversation-summaries/* frissítés."
     fi
+  fi
+fi
+
+# 4b) Canonical local governance hub sync check.
+grep -E -- \
+  '^(scripts/(safe-repo-audit|git-health-check|install-hooks-all)[^[:space:]]*|docs/(pr-policy|impact-hub-governance-system-plan-2026-06-16)[^[:space:]]*\.md|AGENTS\.md$)' \
+  "$FILTERED_CHANGED_LIST" > "$GOVERNANCE_LANE_HITS" || true
+
+if [[ -s "$GOVERNANCE_LANE_HITS" ]]; then
+  grep -E -- \
+    '^docs/impact-hub-governance-system-plan-2026-06-16\.md$' \
+    "$FILTERED_CHANGED_LIST" > "$GOVERNANCE_PLAN_HITS" || true
+
+  if [[ ! -s "$GOVERNANCE_PLAN_HITS" ]]; then
+    echo "INFO: governance lane changes detected (first 40):"
+    sed -n '1,40p' "$GOVERNANCE_LANE_HITS"
+    echo
+    register_warning "governance/guard lane changed without local governance system-plan sync."
   fi
 fi
 

--- a/system-status-snapshot.md
+++ b/system-status-snapshot.md
@@ -3677,3 +3677,4 @@ _Manual update: 2026-03-08 14:02:00_
 ## 2026-03-09 Workflow Infra Update
 - Dev-memory workflow 1-8 aktiválva (pre-task, context-pack, memory gate, PR auto-memory, commit template/hook, incident, digest, Copilot MCP guard).
 - Hookok újratelepítve; napi digest cron aktív.
+2026-06-16T18:20:00Z | feat(dev-guard/local-governance-sync-enforcement): a local pre-push audit most mar fail-closed modon megkoveteli, hogy a guard/governance/policy lane valtozasai a helyi governance system plan frissitesevel egyutt menjenek ki. Erintett fajlok: `scripts/safe-repo-audit.sh`, `scripts/git-health-check.sh`, `AGENTS.md`, `docs/impact-hub-governance-system-plan-2026-06-16.md`.


### PR DESCRIPTION
## Summary
- enforce local governance/masterplan sync on push for governance/guard lane changes
- add local health-check coverage for the push gate
- record continuity in the repo-local governance hub and status notes

## Scope
- local repo governance enforcement only
- no runtime feature behavior change
- no cross-repo writes from this PR

## Validation
- `bash -n scripts/safe-repo-audit.sh`
- `bash -n scripts/git-health-check.sh`
- `git diff --check`
- strict push-range safe audit pass
- `bash scripts/git-health-check.sh`

## Rollback
- revert the guard commit if the gate proves too strict for this repo's actual workflow
